### PR TITLE
Feature/flow actions

### DIFF
--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample.xcodeproj/project.pbxproj
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		176F3CB529B8BF71009C4987 /* ShapesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176F3CB429B8BF71009C4987 /* ShapesView.swift */; };
 		176F3CB829B8C05B009C4987 /* ShapesCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176F3CB729B8C05B009C4987 /* ShapesCoordinator.swift */; };
 		176F3CBB29B8C162009C4987 /* ShapesRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176F3CBA29B8C162009C4987 /* ShapesRoute.swift */; };
+		17AABAED2A6D5CF400AFE8A7 /* SimpleShapesAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17AABAEC2A6D5CF400AFE8A7 /* SimpleShapesAction.swift */; };
+		17AABAEF2A6D5E1500AFE8A7 /* CustomShapesAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17AABAEE2A6D5E1500AFE8A7 /* CustomShapesAction.swift */; };
+		17AABAF12A6D5F2100AFE8A7 /* ShapesAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17AABAF02A6D5F2100AFE8A7 /* ShapesAction.swift */; };
 		17F1183529CC63B1004755DB /* SimpleShapesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F1183429CC63B1004755DB /* SimpleShapesView.swift */; };
 		17F1183729CC63C0004755DB /* CustomShapesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F1183629CC63C0004755DB /* CustomShapesView.swift */; };
 		17F1183B29CC6678004755DB /* SimpleShapesCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F1183A29CC6678004755DB /* SimpleShapesCoordinator.swift */; };
@@ -35,6 +38,9 @@
 		176F3CB429B8BF71009C4987 /* ShapesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapesView.swift; sourceTree = "<group>"; };
 		176F3CB729B8C05B009C4987 /* ShapesCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapesCoordinator.swift; sourceTree = "<group>"; };
 		176F3CBA29B8C162009C4987 /* ShapesRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapesRoute.swift; sourceTree = "<group>"; };
+		17AABAEC2A6D5CF400AFE8A7 /* SimpleShapesAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleShapesAction.swift; sourceTree = "<group>"; };
+		17AABAEE2A6D5E1500AFE8A7 /* CustomShapesAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomShapesAction.swift; sourceTree = "<group>"; };
+		17AABAF02A6D5F2100AFE8A7 /* ShapesAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapesAction.swift; sourceTree = "<group>"; };
 		17E1C1FF2A1BD86D00542AB9 /* SwiftUICoordinator.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftUICoordinator.xctestplan; sourceTree = "<group>"; };
 		17F1183429CC63B1004755DB /* SimpleShapesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleShapesView.swift; sourceTree = "<group>"; };
 		17F1183629CC63C0004755DB /* CustomShapesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomShapesView.swift; sourceTree = "<group>"; };
@@ -136,6 +142,7 @@
 			children = (
 				176F3CB729B8C05B009C4987 /* ShapesCoordinator.swift */,
 				176F3CBA29B8C162009C4987 /* ShapesRoute.swift */,
+				17AABAF02A6D5F2100AFE8A7 /* ShapesAction.swift */,
 			);
 			path = Shapes;
 			sourceTree = "<group>";
@@ -152,6 +159,7 @@
 			children = (
 				17F1183A29CC6678004755DB /* SimpleShapesCoordinator.swift */,
 				17F1183C29CC668F004755DB /* SimpleShapesRoute.swift */,
+				17AABAEC2A6D5CF400AFE8A7 /* SimpleShapesAction.swift */,
 			);
 			path = SimpleShapes;
 			sourceTree = "<group>";
@@ -161,6 +169,7 @@
 			children = (
 				17F1183E29CC8A57004755DB /* CustomShapesCoordinator.swift */,
 				17F1184029CC8A84004755DB /* CustomShapesRoute.swift */,
+				17AABAEE2A6D5E1500AFE8A7 /* CustomShapesAction.swift */,
 			);
 			path = CustomShapes;
 			sourceTree = "<group>";
@@ -246,18 +255,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				17AABAEF2A6D5E1500AFE8A7 /* CustomShapesAction.swift in Sources */,
 				17F1183729CC63C0004755DB /* CustomShapesView.swift in Sources */,
 				17F1183B29CC6678004755DB /* SimpleShapesCoordinator.swift in Sources */,
 				17F1184729CC8F1A004755DB /* Tower.swift in Sources */,
 				17F1184329CC8BA6004755DB /* Triangle.swift in Sources */,
 				1732C9FC29A6607500C2BC1F /* SwiftUICoordinatorExampleApp.swift in Sources */,
 				17F1184529CC8CF6004755DB /* Star.swift in Sources */,
+				17AABAF12A6D5F2100AFE8A7 /* ShapesAction.swift in Sources */,
 				176F3CB829B8C05B009C4987 /* ShapesCoordinator.swift in Sources */,
 				176F3CB529B8BF71009C4987 /* ShapesView.swift in Sources */,
 				17360A412A1275D600DB2296 /* FadeTransition.swift in Sources */,
 				17F1183D29CC668F004755DB /* SimpleShapesRoute.swift in Sources */,
 				17F1183529CC63B1004755DB /* SimpleShapesView.swift in Sources */,
 				176F3CBB29B8C162009C4987 /* ShapesRoute.swift in Sources */,
+				17AABAED2A6D5CF400AFE8A7 /* SimpleShapesAction.swift in Sources */,
 				17F1183F29CC8A57004755DB /* CustomShapesCoordinator.swift in Sources */,
 				17F1184129CC8A84004755DB /* CustomShapesRoute.swift in Sources */,
 			);

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/CustomShapes/CustomShapesAction.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/CustomShapes/CustomShapesAction.swift
@@ -1,0 +1,15 @@
+//
+//  CustomShapesAction.swift
+//  SwiftUICoordinatorExample
+//
+//  Created by Erik Drobne on 23/07/2023.
+//
+
+import Foundation
+import SwiftUICoordinator
+
+enum CustomShapesAction: CoordinatorAction {
+    case triangle
+    case star
+    case tower
+}

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/CustomShapes/CustomShapesCoordinator.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/CustomShapes/CustomShapesCoordinator.swift
@@ -11,7 +11,7 @@ import SwiftUI
 import SwiftUICoordinator
 
 class CustomShapesCoordinator: Routing {
-
+    
     // MARK: - Internal properties
 
     weak var parent: Coordinator? = nil
@@ -27,12 +27,17 @@ class CustomShapesCoordinator: Routing {
         self.startRoute = startRoute
     }
     
-    func navigate(to route: NavigationRoute) {
-        guard let route = route as? CustomShapesRoute else {
-            return
+    func handle(_ action: CoordinatorAction) {
+        switch action {
+        case CustomShapesAction.triangle:
+            try? show(route: .triangle)
+        case CustomShapesAction.star:
+            try? show(route: .star)
+        case CustomShapesAction.tower:
+            try? show(route: .tower)
+        default:
+            parent?.handle(action)
         }
-        
-        try? show(route: route)
     }
 }
 

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/CustomShapes/CustomShapesCoordinator.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/CustomShapes/CustomShapesCoordinator.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import SwiftUI
 import SwiftUICoordinator
 
-class CustomShapesCoordinator: NSObject, Routing {
+class CustomShapesCoordinator: Routing {
 
     // MARK: - Internal properties
 
@@ -25,7 +25,6 @@ class CustomShapesCoordinator: NSObject, Routing {
         self.parent = parent
         self.navigationController = navigationController
         self.startRoute = startRoute
-        super.init()
     }
     
     func navigate(to route: NavigationRoute) {

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/CustomShapes/CustomShapesCoordinator.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/CustomShapes/CustomShapesCoordinator.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import SwiftUI
 import SwiftUICoordinator
 
-class CustomShapesCoordinator: NSObject, Coordinator, Navigator {
+class CustomShapesCoordinator: NSObject, Routing {
 
     // MARK: - Internal properties
 

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/Shapes/ShapesAction.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/Shapes/ShapesAction.swift
@@ -1,0 +1,15 @@
+//
+//  ShapesAction.swift
+//  SwiftUICoordinatorExample
+//
+//  Created by Erik Drobne on 23/07/2023.
+//
+
+import Foundation
+import SwiftUICoordinator
+
+enum ShapesAction: CoordinatorAction {
+    case simpleShapes
+    case customShapes
+    case featuredShape(NavigationRoute)
+}

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/Shapes/ShapesCoordinator.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/Shapes/ShapesCoordinator.swift
@@ -27,27 +27,27 @@ class ShapesCoordinator: Routing {
         setup()
     }
     
-    func navigate(to route: NavigationRoute) {
-        switch route {
-        case ShapesRoute.simpleShapes:
+    func handle(_ action: CoordinatorAction) {
+        switch action {
+        case ShapesAction.simpleShapes:
             let coordinator = makeSimpleShapesCoordinator()
             try? coordinator.start()
-        case ShapesRoute.customShapes:
+        case ShapesAction.customShapes:
             let coordinator = makeCustomShapesCoordinator()
             try? coordinator.start()
-        case ShapesRoute.featuredShape(let route):
+        case let ShapesAction.featuredShape(route):
             switch route {
-            case let shapeRoute as SimpleShapesRoute:
+            case let shapeRoute as SimpleShapesRoute where shapeRoute != .simpleShapes:
                 let coordinator = makeSimpleShapesCoordinator()
                 coordinator.append(routes: [.simpleShapes, shapeRoute])
-            case let shapeRoute as CustomShapesRoute:
+            case let shapeRoute as CustomShapesRoute where shapeRoute != .customShapes:
                 let coordinator = makeCustomShapesCoordinator()
                 coordinator.append(routes: [.customShapes, shapeRoute])
             default:
                 return
             }
         default:
-            return
+            break
         }
     }
     

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/Shapes/ShapesCoordinator.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/Shapes/ShapesCoordinator.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import SwiftUICoordinator
 
-class ShapesCoordinator: NSObject, Coordinator, Navigator {
+class ShapesCoordinator: NSObject, Routing {
 
     // MARK: - Internal properties
 

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/Shapes/ShapesCoordinator.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/Shapes/ShapesCoordinator.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import SwiftUICoordinator
 
-class ShapesCoordinator: NSObject, Routing {
+class ShapesCoordinator: Routing {
 
     // MARK: - Internal properties
 
@@ -23,7 +23,6 @@ class ShapesCoordinator: NSObject, Routing {
     init(startRoute: ShapesRoute) {
         self.navigationController = NavigationController()
         self.startRoute = startRoute
-        super.init()
         
         setup()
     }

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/Shapes/ShapesRoute.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/Shapes/ShapesRoute.swift
@@ -12,7 +12,7 @@ enum ShapesRoute: NavigationRoute {
     case shapes
     case simpleShapes
     case customShapes
-    case featuredShape(NavigationRoute)
+    case featuredShape
 
     var title: String? {
         switch self {

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/SimpleShapes/SimpleShapesAction.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/SimpleShapes/SimpleShapesAction.swift
@@ -1,0 +1,17 @@
+//
+//  SimpleShapesAction.swift
+//  SwiftUICoordinatorExample
+//
+//  Created by Erik Drobne on 23/07/2023.
+//
+
+import Foundation
+import SwiftUICoordinator
+
+enum SimpleShapesAction: CoordinatorAction {
+    case rect
+    case roundedRect
+    case capsule
+    case ellipse
+    case circle
+}

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/SimpleShapes/SimpleShapesCoordinator.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/SimpleShapes/SimpleShapesCoordinator.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import SwiftUICoordinator
 
-class SimpleShapesCoordinator: NSObject, Routing {
+class SimpleShapesCoordinator: Routing {
 
     // MARK: - Internal properties
 
@@ -23,7 +23,6 @@ class SimpleShapesCoordinator: NSObject, Routing {
         self.parent = parent
         self.navigationController = navigationController
         self.startRoute = startRoute
-        super.init()
     }
 
     func presentRoot() {

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/SimpleShapes/SimpleShapesCoordinator.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/SimpleShapes/SimpleShapesCoordinator.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import SwiftUICoordinator
 
-class SimpleShapesCoordinator: NSObject, Coordinator, Navigator {
+class SimpleShapesCoordinator: NSObject, Routing {
 
     // MARK: - Internal properties
 

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/SimpleShapes/SimpleShapesCoordinator.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Coordinators/SimpleShapes/SimpleShapesCoordinator.swift
@@ -34,12 +34,21 @@ class SimpleShapesCoordinator: Routing {
         routing.childCoordinators.removeAll()
     }
     
-    func navigate(to route: NavigationRoute) {
-        guard let route = route as? SimpleShapesRoute else {
-            return
+    func handle(_ action: CoordinatorAction) {
+        switch action {
+        case SimpleShapesAction.rect:
+            try? show(route: .rect)
+        case SimpleShapesAction.roundedRect:
+            try? show(route: .roundedRect)
+        case SimpleShapesAction.capsule:
+            try? show(route: .capsule)
+        case SimpleShapesAction.ellipse:
+            try? show(route: .ellipse)
+        case SimpleShapesAction.circle:
+            try? show(route: .circle)
+        default:
+            parent?.handle(action)
         }
-        
-        try? show(route: route)
     }
 }
 

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Views/CustomShapesView.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Views/CustomShapesView.swift
@@ -42,15 +42,15 @@ extension CustomShapesView {
         var coordinator: Coordinator?
 
         func didTapTriangle() {
-            coordinator?.navigate(to: CustomShapesRoute.triangle)
+            coordinator?.handle(CustomShapesAction.triangle)
         }
 
         func didTapStar() {
-            coordinator?.navigate(to: CustomShapesRoute.star)
+            coordinator?.handle(CustomShapesAction.star)
         }
 
         func didTapTower() {
-            coordinator?.navigate(to: CustomShapesRoute.tower)
+            coordinator?.handle(CustomShapesAction.tower)
         }
     }
 }

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Views/ShapesView.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Views/ShapesView.swift
@@ -42,11 +42,11 @@ extension ShapesView {
         var coordinator: Coordinator?
 
         func didTapBuiltIn() {
-            coordinator?.navigate(to: ShapesRoute.simpleShapes)
+            coordinator?.handle(ShapesAction.simpleShapes)
         }
 
         func didTapCustom() {
-            coordinator?.navigate(to: ShapesRoute.customShapes)
+            coordinator?.handle(ShapesAction.customShapes)
         }
 
         func didTapFeatured() {
@@ -60,7 +60,7 @@ extension ShapesView {
                 return
             }
 
-            coordinator?.navigate(to: ShapesRoute.featuredShape(route))
+            coordinator?.handle(ShapesAction.featuredShape(route))
         }
     }
 }

--- a/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Views/SimpleShapesView.swift
+++ b/Example/SwiftUICoordinatorExample/SwiftUICoordinatorExample/Views/SimpleShapesView.swift
@@ -52,23 +52,23 @@ extension SimpleShapesView {
         var coordinator: Coordinator?
 
         func didTapRectangle() {
-            coordinator?.navigate(to: SimpleShapesRoute.rect)
+            coordinator?.handle(SimpleShapesAction.rect)
         }
 
         func didTapRoundedRectangle() {
-            coordinator?.navigate(to: SimpleShapesRoute.roundedRect)
+            coordinator?.handle(SimpleShapesAction.roundedRect)
         }
 
         func didTapCapsule() {
-            coordinator?.navigate(to: SimpleShapesRoute.capsule)
+            coordinator?.handle(SimpleShapesAction.capsule)
         }
 
         func didTapEllipse() {
-            coordinator?.navigate(to: SimpleShapesRoute.ellipse)
+            coordinator?.handle(SimpleShapesAction.ellipse)
         }
 
         func didTapCircle() {
-            coordinator?.navigate(to: SimpleShapesRoute.circle)
+            coordinator?.handle(SimpleShapesAction.circle)
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ enum ShapesRoute: NavigationRoute {
 Our `ShapesCoordinator` has to conform to the `Navigator` protocol and implement the `navigate(to route: NavigationRoute)` to execute flow-specific logic on method execution. Root coordinator has to initialize `NavigationController`.
 
 ```Swift
-class ShapesCoordinator: NSObject, Coordinator, Navigator {
+class ShapesCoordinator: NSObject, Routing {
 
     // MARK: - Internal properties
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ enum ShapesRoute: NavigationRoute {
 Our `ShapesCoordinator` has to conform to the `Navigator` protocol and implement the `navigate(to route: NavigationRoute)` to execute flow-specific logic on method execution. Root coordinator has to initialize `NavigationController`.
 
 ```Swift
-class ShapesCoordinator: NSObject, Routing {
+class ShapesCoordinator: Routing {
 
     // MARK: - Internal properties
 

--- a/Sources/SwiftUICoordinator/Coordinator/Coordinator.swift
+++ b/Sources/SwiftUICoordinator/Coordinator/Coordinator.swift
@@ -14,7 +14,7 @@ public protocol Coordinator: AnyObject {
     /// An array that stores references to any child coordinators.
     var childCoordinators: [Coordinator] { get set }
     
-    /// Takes action parameter and handles it.
+    /// Takes action parameter and handles the `CoordinatorAction`.
     func handle(_ action: CoordinatorAction)
     /// Adds child coordinator to the list.
     func add(child: Coordinator)

--- a/Sources/SwiftUICoordinator/Coordinator/Coordinator.swift
+++ b/Sources/SwiftUICoordinator/Coordinator/Coordinator.swift
@@ -5,16 +5,16 @@
 //  Created by Erik Drobne on 12/12/2022.
 //
 
-import SwiftUI
+import Foundation
 
 @MainActor
 public protocol Coordinator: AnyObject {
     var parent: Coordinator? { get }
     var childCoordinators: [Coordinator] { get set }
     
+    func handle(_ action: CoordinatorAction)
     func add(child: Coordinator)
-    func navigate(to route: NavigationRoute)
-    func finish()
+    func removeFromParent()
 }
 
 // MARK: - Extensions
@@ -22,14 +22,14 @@ public protocol Coordinator: AnyObject {
 public extension Coordinator {
     
     // MARK: - Public methods
-    
-    func finish() {
-        parent?.childCoordinators.removeAll(where: { $0 === self })
-    }
 
-    func add(child: Coordinator) {
+    func add(child: any Coordinator) {
         if !childCoordinators.contains(where: { $0 === child }) {
             childCoordinators.append(child)
         }
+    }
+    
+    func removeFromParent() {
+        parent?.childCoordinators.removeAll(where: { $0 === self })
     }
 }

--- a/Sources/SwiftUICoordinator/Coordinator/Coordinator.swift
+++ b/Sources/SwiftUICoordinator/Coordinator/Coordinator.swift
@@ -9,12 +9,17 @@ import Foundation
 
 @MainActor
 public protocol Coordinator: AnyObject {
+    /// A property that stores a reference to the parent coordinator, if any.
     var parent: Coordinator? { get }
+    /// An array that stores references to any child coordinators.
     var childCoordinators: [Coordinator] { get set }
     
+    /// Takes action parameter and handles it.
     func handle(_ action: CoordinatorAction)
+    /// Adds child coordinator to the list.
     func add(child: Coordinator)
-    func removeFromParent()
+    /// Removes the coordinator from the list of children.
+    func remove(coordinator: Coordinator)
 }
 
 // MARK: - Extensions
@@ -23,13 +28,13 @@ public extension Coordinator {
     
     // MARK: - Public methods
 
-    func add(child: any Coordinator) {
+    func add(child: Coordinator) {
         if !childCoordinators.contains(where: { $0 === child }) {
             childCoordinators.append(child)
         }
     }
     
-    func removeFromParent() {
-        parent?.childCoordinators.removeAll(where: { $0 === self })
+    func remove(coordinator: Coordinator) {
+        childCoordinators.removeAll(where: { $0 === coordinator })
     }
 }

--- a/Sources/SwiftUICoordinator/Coordinator/CoordinatorAction.swift
+++ b/Sources/SwiftUICoordinator/Coordinator/CoordinatorAction.swift
@@ -9,6 +9,7 @@ import Foundation
 
 public protocol CoordinatorAction {}
 
+/// Essential actions.
 public enum Action: CoordinatorAction {
     case done(Any)
     case cancel(Any)

--- a/Sources/SwiftUICoordinator/Coordinator/CoordinatorAction.swift
+++ b/Sources/SwiftUICoordinator/Coordinator/CoordinatorAction.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public protocol CoordinatorAction {}
 
-enum Action: CoordinatorAction {
+public enum Action: CoordinatorAction {
     case done(Any)
     case cancel(Any)
 }

--- a/Sources/SwiftUICoordinator/Coordinator/CoordinatorAction.swift
+++ b/Sources/SwiftUICoordinator/Coordinator/CoordinatorAction.swift
@@ -1,0 +1,15 @@
+//
+//  CoordinatorAction.swift
+//  
+//
+//  Created by Erik Drobne on 23/07/2023.
+//
+
+import Foundation
+
+public protocol CoordinatorAction {}
+
+enum Action: CoordinatorAction {
+    case done(Any)
+    case cancel(Any)
+}

--- a/Sources/SwiftUICoordinator/Navigator/Navigator.swift
+++ b/Sources/SwiftUICoordinator/Navigator/Navigator.swift
@@ -14,14 +14,22 @@ public protocol Navigator: ObservableObject {
     associatedtype Route: NavigationRoute
 
     var navigationController: NavigationController { get }
+    /// The starting route of the navigator.
     var startRoute: Route { get }
     
+    /// This method should be called to show the view for the `startRoute`.
     func start() throws
+    /// It creates a view for the route and adds it to the navigation stack.
     func show(route: Route) throws
+    /// Creates views for routes, and replaces the navigation stack with the specified views.
     func set(routes: [Route], animated: Bool)
+    /// Creates views for routes, and appends them on the navigation stack.
     func append(routes: [Route], animated: Bool)
+    /// Pops the top view from the navigation stack.
     func pop(animated: Bool)
+    /// Pops all the views on the stack except the root view.
     func popToRoot(animated: Bool)
+    /// Dismisses the view.
     func dismiss(animated: Bool)
 }
 

--- a/Sources/SwiftUICoordinator/Navigator/Navigator.swift
+++ b/Sources/SwiftUICoordinator/Navigator/Navigator.swift
@@ -17,7 +17,7 @@ public protocol Navigator: ObservableObject {
     /// The starting route of the navigator.
     var startRoute: Route { get }
     
-    /// This method should be called to show the view for the `startRoute`.
+    /// This method should be called to start the flow  and to show the view for the `startRoute`.
     func start() throws
     /// It creates a view for the route and adds it to the navigation stack.
     func show(route: Route) throws

--- a/Tests/SwiftUICoordinatorTests/Mocks/MockCoordinator.swift
+++ b/Tests/SwiftUICoordinatorTests/Mocks/MockCoordinator.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 @testable import SwiftUICoordinator
 
-class MockCoordinator: NSObject, Coordinator, Navigator {
+class MockCoordinator: NSObject, Routing {
     var parent: Coordinator?
     var childCoordinators = [Coordinator]()
     var navigationController: NavigationController

--- a/Tests/SwiftUICoordinatorTests/Mocks/MockCoordinator.swift
+++ b/Tests/SwiftUICoordinatorTests/Mocks/MockCoordinator.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 @testable import SwiftUICoordinator
 
-class MockCoordinator: NSObject, Routing {
+class MockCoordinator: Routing {
     var parent: Coordinator?
     var childCoordinators = [Coordinator]()
     var navigationController: NavigationController
@@ -18,7 +18,6 @@ class MockCoordinator: NSObject, Routing {
         self.parent = parent
         self.navigationController = NavigationController()
         self.startRoute = startRoute
-        super.init()
     }
     
     func navigate(to route: NavigationRoute) {

--- a/Tests/SwiftUICoordinatorTests/Mocks/MockCoordinator.swift
+++ b/Tests/SwiftUICoordinatorTests/Mocks/MockCoordinator.swift
@@ -9,6 +9,7 @@ import SwiftUI
 @testable import SwiftUICoordinator
 
 class MockCoordinator: Routing {
+    
     var parent: Coordinator?
     var childCoordinators = [Coordinator]()
     var navigationController: NavigationController
@@ -20,7 +21,7 @@ class MockCoordinator: Routing {
         self.startRoute = startRoute
     }
     
-    func navigate(to route: NavigationRoute) {
+    func handle(_ action: CoordinatorAction) {
         
     }
 }

--- a/Tests/SwiftUICoordinatorTests/SwiftUICoordinatorTests.swift
+++ b/Tests/SwiftUICoordinatorTests/SwiftUICoordinatorTests.swift
@@ -14,12 +14,12 @@ import SwiftUI
         XCTAssertEqual(rootCoordinator.childCoordinators.count, 1)
     }
     
-    func testFinishChildCoordinator() {
+    func testRemoveChildCoordinator() {
         let rootCoordinator = MockCoordinator(parent: nil, startRoute: .circle)
         let childCoordinator = MockCoordinator(parent: rootCoordinator, startRoute: .rectangle)
         
         rootCoordinator.add(child: childCoordinator)
-        childCoordinator.finish()
+        rootCoordinator.remove(coordinator: childCoordinator)
         
         XCTAssertEqual(rootCoordinator.childCoordinators.count, 0)
     }


### PR DESCRIPTION
- Introduce the `CoordinatorAction` type and actions handler method `func handle(_ action: CoordinatorAction)` instead of direct route navigation
- Improve documentation
- Add a method `func remove(coordinator: Coordinator)` which takes a `Coordinator` as a parameter and removes it from the list of child's list.
- Update unit tests.
- `Coordinator` is not conforming to the `NSObject` anymore.
