### PR TITLE
[WIP] Route appearance

### DIFF
--- a/Sources/SwiftUICoordinator/Routing/Route/NavigationRoute.swift
+++ b/Sources/SwiftUICoordinator/Routing/Route/NavigationRoute.swift
@@ -5,11 +5,21 @@
 //  Created by Erik Drobne on 12/12/2022.
 //
 
+import Foundation
+
 @MainActor
 public protocol NavigationRoute {
     /// This title can be used to set the navigation bar title when the route is shown.
     var title: String? { get }
+    /// A property that provides the info about the appearance and styling of a route in the navigation system.
+    var appearance: RouteAppearance? { get }
     /// Transition action to be used when the route is shown.
     /// This can be a push action, a modal presentation, or `nil` (for child coordinators).
     var action: TransitionAction? { get }
+}
+
+public extension NavigationRoute {
+    var appearance: RouteAppearance? {
+        return nil
+    }
 }

--- a/Sources/SwiftUICoordinator/Routing/Route/RouteAppearance.swift
+++ b/Sources/SwiftUICoordinator/Routing/Route/RouteAppearance.swift
@@ -1,0 +1,12 @@
+//
+//  File.swift
+//  
+//
+//  Created by Erik Drobne on 17/09/2023.
+//
+
+import SwiftUI
+
+public struct RouteAppearance {
+    let background: UIColor
+}

--- a/Sources/SwiftUICoordinator/Routing/RouteHostingController.swift
+++ b/Sources/SwiftUICoordinator/Routing/RouteHostingController.swift
@@ -24,4 +24,12 @@ public class RouteHostingController<Content: View>: UIHostingController<Content>
     @objc required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    // MARK: - Lifecycle
+    
+    public override func viewDidLoad() {
+        if let appearance = route.appearance {
+            self.view.backgroundColor = appearance.background
+        }
+    }
 }


### PR DESCRIPTION
When presenting the view modally we would like to have an option to set the background opacity of a containing view.
This can now be achieved with the new `RouteAppearance` property which could be set on `NavigationRoute`.