### PR TITLE
feat: shows/hides back button and navigation bar

### DIFF
--- a/Sources/SwiftUICoordinator/Navigator/Navigator.swift
+++ b/Sources/SwiftUICoordinator/Navigator/Navigator.swift
@@ -60,8 +60,8 @@ public extension Navigator where Self: RouterViewFactory {
 
     func show(route: Route) throws {
         let viewController = self.hostingController(for: route)
-        navigationController.isNavigationBarHidden = route.title == nil
-        
+        navigationController.isNavigationBarHidden = route.title == nil && route.hidesNavigationBar ?? true
+
         switch route.action {
         case .push(let animated):
             navigationController.pushViewController(viewController, animated: animated)
@@ -80,13 +80,13 @@ public extension Navigator where Self: RouterViewFactory {
 
     func set(routes: [Route], animated: Bool = true) {
         let views = views(for: routes)
-        navigationController.isNavigationBarHidden = routes.last?.title == nil
+        navigationController.isNavigationBarHidden = routes.last?.title == nil && routes.last?.hidesNavigationBar ?? true
         navigationController.setViewControllers(views, animated: animated)
     }
 
     func append(routes: [Route], animated: Bool = true) {
         let views = views(for: routes)
-        navigationController.isNavigationBarHidden = routes.last?.title == nil
+        navigationController.isNavigationBarHidden = routes.last?.title == nil && routes.last?.hidesNavigationBar ?? true
         navigationController.setViewControllers(self.viewControllers + views, animated: animated)
     }
 

--- a/Sources/SwiftUICoordinator/Routing/Route/NavigationRoute.swift
+++ b/Sources/SwiftUICoordinator/Routing/Route/NavigationRoute.swift
@@ -18,6 +18,10 @@ public protocol NavigationRoute {
     var action: TransitionAction? { get }
     /// A property that indicates whether the Coordinator should be attached to the View as an EnvironmentObject.
     var attachCoordinator: Bool { get }
+    /// A property that hides the back button during navigation
+    var hidesBackButton: Bool? { get }
+    /// A property that hides the navigation bar
+    var hidesNavigationBar: Bool? { get }
 }
 
 public extension NavigationRoute {
@@ -34,6 +38,14 @@ public extension NavigationRoute {
     }
     
     var action: TransitionAction? {
+        return nil
+    }
+
+    var hidesBackButton: Bool? {
+        return nil
+    }
+
+    var hidesNavigationBar: Bool? {
         return nil
     }
 }

--- a/Sources/SwiftUICoordinator/Routing/RouteHostingController.swift
+++ b/Sources/SwiftUICoordinator/Routing/RouteHostingController.swift
@@ -36,5 +36,9 @@ public class RouteHostingController<Content: View>: UIHostingController<Content>
         if let appearance = route.appearance {
             self.view.backgroundColor = appearance.background
         }
+
+        if let hidesBackButton = route.hidesBackButton {
+            self.navigationItem.setHidesBackButton(hidesBackButton, animated: false)
+        }
     }
 }


### PR DESCRIPTION
This PR is intended to add two properties in the `navigationRoute` protocol to allow the developer to show or hide the back button during the navigation transition and to control the visibility of the navigation bar even if the title isn't defined.

Closes #41 