### PR TITLE
TabBarCoordinator: Make TabBarController an associated type

### DIFF
--- a/Sources/SwiftUICoordinator/TabBarCoordinator/TabBarCoordinator.swift
+++ b/Sources/SwiftUICoordinator/TabBarCoordinator/TabBarCoordinator.swift
@@ -6,10 +6,11 @@ public typealias TabBarRouting = Coordinator & TabBarCoordinator
 @MainActor
 public protocol TabBarCoordinator: ObservableObject {
     associatedtype Route: TabBarNavigationRoute
+    associatedtype TabBarController: UITabBarController
     
     var navigationController: NavigationController { get }
     /// The tab bar controller that manages the tab bar interface.
-    var tabBarController: UITabBarController { get }
+    var tabBarController: TabBarController { get }
     /// The tabs available in the tab bar interface, represented by `Route` types.
     var tabs: [Route] { get }
     /// This method should be called to show the `tabBarController`.


### PR DESCRIPTION
This PR introduces an associated type for `TabBarController`.
This change provides a more generic and flexible way to work with different types of tab bar controllers.

This PR introduces an associated type for `TabBarController` in the `TabBarCoordinator` protocol, enhancing flexibility by allowing the use of custom tab bar controller types. This way we can also implement a custom `UITabBarControllerDelegate` for more control over tab bar interactions.