### PR TITLE
Feature/swift testing

### DIFF
--- a/Tests/SwiftUICoordinatorTests/DeepLinkHandlerTests.swift
+++ b/Tests/SwiftUICoordinatorTests/DeepLinkHandlerTests.swift
@@ -5,8 +5,8 @@
 //  Created by Erik Drobne on 17/09/2023.
 //
 
-import Testing
 import Foundation
+import Testing
 @testable import SwiftUICoordinator
 
 @MainActor

--- a/Tests/SwiftUICoordinatorTests/DeepLinkTests.swift
+++ b/Tests/SwiftUICoordinatorTests/DeepLinkTests.swift
@@ -4,8 +4,9 @@
 //
 //  Created by Erik Drobne on 17/09/2023.
 //
-import Testing
+
 import Foundation
+import Testing
 @testable import SwiftUICoordinator
 
 @MainActor

--- a/Tests/SwiftUICoordinatorTests/DeepLinkTests.swift
+++ b/Tests/SwiftUICoordinatorTests/DeepLinkTests.swift
@@ -1,33 +1,37 @@
 //
-//  File.swift
+//  DeepLinkTests.swift
 //  
 //
 //  Created by Erik Drobne on 17/09/2023.
 //
-
+import Testing
 import Foundation
-import XCTest
 @testable import SwiftUICoordinator
 
-final class DeepLinkTests: XCTestCase {
+@MainActor
+@Suite("Deep Link Tests") struct DeepLinkTests {
 
-    func test_deepLinksWithoutParametersAreEqual() {
+    @Test func testDeepLinksWithoutParametersAreEqual() {
+        // Arrange
         let linkA = DeepLink(action: "square", route: MockRoute.square)
         let linkB = DeepLink(action: "square", route: MockRoute.square)
         let linkC = DeepLink(action: "rectangle", route: MockRoute.rectangle)
 
-        XCTAssertEqual(linkA, linkB)
-        XCTAssertNotEqual(linkA, linkC)
-        XCTAssertNotEqual(linkB, linkC)
+        // Assert
+        #expect(linkA == linkB)
+        #expect(linkA != linkC)
+        #expect(linkB != linkC)
     }
 
-    func test_deepLinksWithParametersAreEqual() {
+    @Test func testDeepLinksWithParametersAreEqual() {
+        // Arrange
         let linkA = DeepLink(action: "square", route: MockRoute.square, params: [])
         let linkB = DeepLink(action: "square", route: MockRoute.square, params: ["color"])
         let linkC = DeepLink(action: "square", route: MockRoute.rectangle, params: ["width"])
 
-        XCTAssertEqual(linkA, linkB)
-        XCTAssertEqual(linkA, linkC)
-        XCTAssertEqual(linkB, linkC)
+        // Assert
+        #expect(linkA == linkB)
+        #expect(linkA == linkC)
+        #expect(linkB == linkC)
     }
 }

--- a/Tests/SwiftUICoordinatorTests/NavigationControllerTests.swift
+++ b/Tests/SwiftUICoordinatorTests/NavigationControllerTests.swift
@@ -5,40 +5,42 @@
 //  Created by Erik Drobne on 23/09/2023.
 //
 
-import Foundation
-import XCTest
+import Testing
 @testable import SwiftUICoordinator
 
-final class NavigationControllerTests: XCTestCase {
+@MainActor
+@Suite("Navigation Controller Tests") struct NavigationControllerTests {
 
-    @MainActor
-    func testNavigationBarIsHiddenByDefault() {
+    @Test func testNavigationBarIsHiddenByDefault() {
         // Act
         let navigationController = NavigationController()
+        
         // Assert
-        XCTAssertTrue(navigationController.isNavigationBarHidden)
+        #expect(navigationController.isNavigationBarHidden)
     }
 
-    @MainActor
-    func testNavigationBarIsNotHidden() {
+    @Test func testNavigationBarIsNotHidden() {
         // Act
         let navigationController = NavigationController(isNavigationBarHidden: false)
+        
         // Assert
-        XCTAssertFalse(navigationController.isNavigationBarHidden)
+        #expect(!navigationController.isNavigationBarHidden)
     }
     
-    @MainActor
-    func testNavigationControllerDelegate() {
+    @Test func testNavigationControllerDelegate() {
         // Arrange
         let transitionDelegate = NavigationControllerFactory().makeTransitionDelegate([])
-        let navigationController = NavigationController(isNavigationBarHidden: false, delegate: transitionDelegate)
+        let navigationController = NavigationController(
+            isNavigationBarHidden: false,
+            delegate: transitionDelegate
+        )
         
         // Act
         let currentDelegate = navigationController.delegate
         
         // Assert
-        XCTAssertNotNil(currentDelegate, "Delegate should not be nil")
-        XCTAssertTrue(
+        #expect(currentDelegate != nil, "Delegate should not be nil")
+        #expect(
             currentDelegate === transitionDelegate,
             "Delegate should be of type NavigationControllerTransitionDelegate"
         )

--- a/Tests/SwiftUICoordinatorTests/NavigationControllerTransitionHandlerTests.swift
+++ b/Tests/SwiftUICoordinatorTests/NavigationControllerTransitionHandlerTests.swift
@@ -5,8 +5,8 @@
 //  Created by Erik Drobne on 23. 10. 23.
 //
 
-import Testing
 import UIKit
+import Testing
 @testable import SwiftUICoordinator
 
 @MainActor

--- a/Tests/SwiftUICoordinatorTests/RootCoordinatorTests.swift
+++ b/Tests/SwiftUICoordinatorTests/RootCoordinatorTests.swift
@@ -5,21 +5,26 @@
 //  Created by Erik Drobne on 10. 10. 23.
 //
 
-import XCTest
+import Testing
+import UIKit
 @testable import SwiftUICoordinator
 
-final class RootCoordinatorTests: XCTestCase {
+@MainActor
+@Suite("Root Coordinator Tests") struct RootCoordinatorTests {
 
-    @MainActor
-    func test_rootViewControllerInitialization() {
+    @Test func testRootViewControllerInitialization() {
+        // Arrange
         let navigationController = NavigationController()
         let window = UIWindow()
-        let sut = MockAppCoordinator(window: window, navigationController: navigationController)
-
-        XCTAssertEqual(sut.window, window)
-        XCTAssertTrue(sut.window.isKeyWindow)
-        XCTAssertFalse(sut.window.isHidden)
-        XCTAssertEqual(sut.window.rootViewController, navigationController)
-        XCTAssertTrue(sut.childCoordinators.isEmpty)
+        
+        // Act
+        let coordinator = MockAppCoordinator(window: window, navigationController: navigationController)
+        
+        // Assert
+        #expect(coordinator.window == window)
+        #expect(coordinator.window.isKeyWindow)
+        #expect(!coordinator.window.isHidden)
+        #expect(coordinator.window.rootViewController == navigationController)
+        #expect(coordinator.childCoordinators.isEmpty)
     }
 }

--- a/Tests/SwiftUICoordinatorTests/TransitionTests.swift
+++ b/Tests/SwiftUICoordinatorTests/TransitionTests.swift
@@ -5,23 +5,51 @@
 //  Created by Erik Drobne on 10. 10. 23.
 //
 
-import XCTest
+import Testing
 import Foundation
 @testable import SwiftUICoordinator
 
-final class TransitionTests: XCTestCase {
+@MainActor
+@Suite("Transition Tests") struct TransitionTests {
 
-    @MainActor
-    func test_registerTransitions() {
+    @Test func testRegisterTransitions() {
+        // Arrange
         let transition = MockTransition()
         let transitionHandler = NavigationControllerTransitionHandler(transitions: [transition])
+        
+        // Act
         let delegateProxy = NavigationControllerTransitionDelegate(transitionHandler: transitionHandler)
-
-        guard let sut = delegateProxy.transitionHandler.transitions[0] as? MockTransition else {
-            XCTFail("Cannot cast to MockTransition.")
-            return
-        }
-
-        XCTAssertEqual(sut, transition)
+        let registeredTransition = delegateProxy.transitionHandler.transitions[0]
+        
+        // Assert
+        #expect(registeredTransition is MockTransition)
+        #expect(registeredTransition as? MockTransition == transition)
+    }
+    
+    @Test func testEmptyTransitions() {
+        // Arrange
+        let transitionHandler = NavigationControllerTransitionHandler(transitions: [])
+        
+        // Act
+        let delegateProxy = NavigationControllerTransitionDelegate(transitionHandler: transitionHandler)
+        
+        // Assert
+        #expect(delegateProxy.transitionHandler.transitions.isEmpty)
+    }
+    
+    @Test func testMultipleTransitions() {
+        // Arrange
+        let transition1 = MockTransition()
+        let transition2 = MockTransition()
+        let transitions = [transition1, transition2]
+        
+        // Act
+        let transitionHandler = NavigationControllerTransitionHandler(transitions: transitions)
+        let delegateProxy = NavigationControllerTransitionDelegate(transitionHandler: transitionHandler)
+        
+        // Assert
+        #expect(delegateProxy.transitionHandler.transitions.count == 2)
+        #expect(delegateProxy.transitionHandler.transitions[0] as? MockTransition == transition1)
+        #expect(delegateProxy.transitionHandler.transitions[1] as? MockTransition == transition2)
     }
 }


### PR DESCRIPTION
This pull request refactors the test suite for the `SwiftUICoordinator` project, transitioning from XCTest to a new testing framework. The changes include updating the test structure and assertions to align with the new framework's syntax and features.

### Test Framework Transition:

* [`Tests/SwiftUICoordinatorTests/DeepLinkHandlerTests.swift`](diffhunk://#diff-e867cfab2b06f145b52134c95d1c05670bc25e5ef804a4819b8645a2caae6e38L8-R109): Replaced `XCTest` with the new testing framework, updated test methods to use the new `@Suite` and `@Test` annotations, and replaced `XCTAssert` statements with `#expect` assertions.

* [`Tests/SwiftUICoordinatorTests/DeepLinkTests.swift`](diffhunk://#diff-a2fe9cb1a5a8798854311e6623bf375ae5b32a7f12d982e39763feb78235b607L2-R35): Updated file name and transitioned from `XCTest` to the new testing framework, using `@Suite` and `@Test` annotations, with appropriate `#expect` assertions.

* [`Tests/SwiftUICoordinatorTests/NavigationControllerTests.swift`](diffhunk://#diff-3d9f3233ad4af276cab9417bd54110bacd1f9b41b90253844993f00815da7ba4L8-R43): Transitioned from `XCTest` to the new testing framework, incorporating `@Suite` and `@Test` annotations, and replaced `XCTAssert` statements with `#expect` assertions.

* [`Tests/SwiftUICoordinatorTests/RootCoordinatorTests.swift`](diffhunk://#diff-0e2ea0ad9c1a35b2fdb9fba44d13c76db957e5336d4c050ea8d84bb7028fb7e3L8-R28): Switched from `XCTest` to the new testing framework, using `@Suite` and `@Test` annotations, and updated assertions to `#expect`.

* [`Tests/SwiftUICoordinatorTests/TransitionTests.swift`](diffhunk://#diff-e1de926c67ca00fe9e6edc96664dfab27c0facc92aa18abe20654aa3c0e3c594L8-R53): Converted tests from `XCTest` to the new testing framework, adopting `@Suite` and `@Test` annotations, and replaced `XCTAssert` statements with `#expect` assertions.