### PR TITLE
feature(route): remove attach coordinator property

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Define your navigation paths:
 protocol NavigationRoute {
     var title: String? { get }
     var appearance: RouteAppearance? { get }
-    var attachCoordinator: Bool { get }
     var hidesNavigationBar: Bool? { get }
 }
 

--- a/Sources/SwiftUICoordinator/Routing/Route/NavigationRoute.swift
+++ b/Sources/SwiftUICoordinator/Routing/Route/NavigationRoute.swift
@@ -13,8 +13,6 @@ public protocol NavigationRoute {
     var title: String? { get }
     /// A property that provides the info about the appearance and styling of a route in the navigation system.
     var appearance: RouteAppearance? { get }
-    /// A property that indicates whether the Coordinator should be attached to the View as an EnvironmentObject.
-    var attachCoordinator: Bool { get }
     /// A property that hides the navigation bar
     var hidesNavigationBar: Bool? { get }
 }
@@ -31,7 +29,6 @@ public protocol StackNavigationRoute: NavigationRoute {
 public extension NavigationRoute {
     var title: String? { return nil }
     var appearance: RouteAppearance? { return nil }
-    var attachCoordinator: Bool { return true }
     var hidesNavigationBar: Bool? { return nil }
 }
 

--- a/Sources/SwiftUICoordinator/Routing/Route/RouterViewFactory.swift
+++ b/Sources/SwiftUICoordinator/Routing/Route/RouterViewFactory.swift
@@ -28,9 +28,6 @@ extension RouterViewFactory where Self: ObservableObject {
             .ifLet(route.title) { view, value in
                 view.navigationTitle(value)
             }
-            .if(route.attachCoordinator) { view in
-                view.environmentObject(self)
-            }
 
         return RouteHostingController(
             rootView: view,

--- a/Sources/SwiftUICoordinator/Utilities/View+Utilities.swift
+++ b/Sources/SwiftUICoordinator/Utilities/View+Utilities.swift
@@ -16,13 +16,4 @@ extension View {
             self
         }
     }
-
-    @ViewBuilder
-    func `if`<Content: View>(_ conditional: Bool, content: (Self) -> Content) -> some View {
-        if conditional {
-            content(self)
-        } else {
-            self
-        }
-    }
 }

--- a/Tests/SwiftUICoordinatorTests/Mocks/Coordinator/MockRoute.swift
+++ b/Tests/SwiftUICoordinatorTests/Mocks/Coordinator/MockRoute.swift
@@ -15,7 +15,6 @@ enum MockRoute: StackNavigationRoute {
     
     var title: String? { nil }
     var appearance: RouteAppearance? { nil }
-    var attachCoordinator: Bool { true }
     var hidesNavigationBar: Bool? { nil }
     var hidesBackButton: Bool? { nil }
     


### PR DESCRIPTION
This pull request involves the removal of the `attachCoordinator` property from the `NavigationRoute` protocol and related code. The changes simplify the navigation route definitions and remove unnecessary code.

Key changes include:

### Removal of `attachCoordinator` property:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88): Removed the `attachCoordinator` property from the `NavigationRoute` protocol definition.
* [`Sources/SwiftUICoordinator/Routing/Route/NavigationRoute.swift`](diffhunk://#diff-934cf68bf4dca10f7b33010ff0a849fc5094d809cb59392d7f17efa8c6cf5f09L16-L17): Removed the `attachCoordinator` property from the `NavigationRoute` protocol and its default implementation. [[1]](diffhunk://#diff-934cf68bf4dca10f7b33010ff0a849fc5094d809cb59392d7f17efa8c6cf5f09L16-L17) [[2]](diffhunk://#diff-934cf68bf4dca10f7b33010ff0a849fc5094d809cb59392d7f17efa8c6cf5f09L34)
* [`Tests/SwiftUICoordinatorTests/Mocks/Coordinator/MockRoute.swift`](diffhunk://#diff-4c1c837a57c9a0bd1cf5d1a262bb6fb13aa683ed6300523e029b1c4f69dd55f8L18): Removed the `attachCoordinator` property from the `MockRoute` enum.

### Code simplification:

* [`Sources/SwiftUICoordinator/Routing/Route/RouterViewFactory.swift`](diffhunk://#diff-58139c08a208eebea742962e06c99b702c75935bcb167c893a0990da92183fecL31-L33): Removed the code that sets the environment object based on the `attachCoordinator` property.
* [`Sources/SwiftUICoordinator/Utilities/View+Utilities.swift`](diffhunk://#diff-da06e8f1c08e8ef78e3d0b9d873d48a722897e2936304f9454a37af28cda3609L19-L27): Removed the `if` view modifier extension method, which is no longer needed.